### PR TITLE
Feature/tao 7854/accept http client options when call remote environment

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=6.0.0',
-        'tao' => '>=21.0.0'
+        'tao' => '>=31.6.0'
     ),
 	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoPublishingManager',
     'acl' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '1.3.0',
+    'version' => '2.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=6.0.0',

--- a/model/PlatformService.php
+++ b/model/PlatformService.php
@@ -51,6 +51,7 @@ class PlatformService extends \tao_models_classes_ClassService
     /**
      * @param $platformId
      * @param RequestInterface $request
+     * @param array $clientOptions Http client options
      * @return mixed|ResponseInterface
      * @throws \common_Exception
      * @throws \core_kernel_classes_EmptyProperty

--- a/model/PlatformService.php
+++ b/model/PlatformService.php
@@ -55,7 +55,7 @@ class PlatformService extends \tao_models_classes_ClassService
      * @throws \common_Exception
      * @throws \core_kernel_classes_EmptyProperty
      */
-    public function callApi($platformId, RequestInterface $request)
+    public function callApi($platformId, RequestInterface $request, array $clientOptions = [])
     {
         $platform = $this->getResource($platformId);
         $rootUrl = $platform->getUniquePropertyValue($this->getProperty(self::PROPERTY_ROOT_URL));
@@ -73,6 +73,6 @@ class PlatformService extends \tao_models_classes_ClassService
         $absUrl = $rootUrl.ltrim($relUrl,'/');
         $request = $request->withUri(new Uri($absUrl));
 
-        return $authenticator->call($request);
+        return $authenticator->call($request, $clientOptions);
     }
 }

--- a/model/publishing/PublishingService.php
+++ b/model/publishing/PublishingService.php
@@ -79,19 +79,20 @@ class PublishingService extends ConfigurableService
      *
      * @param $action
      * @param RequestInterface $request
+     * @param array $clientOptions Http client options
      * @return ResponseInterface
      * @throws \common_Exception
      * @throws \common_exception_NotFound
      * @throws \core_kernel_classes_EmptyProperty
      */
-    public function callEnvironment($action, RequestInterface $request, array $clientOprions = [])
+    public function callEnvironment($action, RequestInterface $request, array $clientOptions = [])
     {
         $environment = $this->findOneEnvironmentByAction($action);
         $boxId = $this->getEnvironmentBoxId($environment);
 
         $request = $request->withHeader('x-tao-box-id', $boxId->literal);
 
-        return PlatformService::singleton()->callApi($environment->getUri(), $request, $clientOprions);
+        return PlatformService::singleton()->callApi($environment->getUri(), $request, $clientOptions);
     }
 
     /**

--- a/model/publishing/PublishingService.php
+++ b/model/publishing/PublishingService.php
@@ -84,14 +84,14 @@ class PublishingService extends ConfigurableService
      * @throws \common_exception_NotFound
      * @throws \core_kernel_classes_EmptyProperty
      */
-    public function callEnvironment($action, RequestInterface $request)
+    public function callEnvironment($action, RequestInterface $request, array $clientOprions = [])
     {
         $environment = $this->findOneEnvironmentByAction($action);
         $boxId = $this->getEnvironmentBoxId($environment);
 
         $request = $request->withHeader('x-tao-box-id', $boxId->literal);
 
-        return PlatformService::singleton()->callApi($environment->getUri(), $request);
+        return PlatformService::singleton()->callApi($environment->getUri(), $request, $clientOprions);
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -247,6 +247,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.2.0');
         }
 
-        $this->skip('1.2.0', '1.3.0');
+        $this->skip('1.2.0', '2.0.0');
     }
 }

--- a/views/build/.htaccess
+++ b/views/build/.htaccess
@@ -1,4 +1,0 @@
-<IfModule mod_rewrite.c>
-RewriteEngine On
-RewriteRule ^.*$ - [F]
-</IfModule>

--- a/views/build/.htaccess
+++ b/views/build/.htaccess
@@ -1,0 +1,4 @@
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule ^.*$ - [F]
+</IfModule>


### PR DESCRIPTION
Accept http client options when call remote environment
Requires https://github.com/oat-sa/tao-core/pull/2068 and https://github.com/oat-sa/extension-tao-oauth/pull/31