### PR TITLE
Fix/tao 7326/decode htmlchars in password

### DIFF
--- a/controller/PlatformAdmin.php
+++ b/controller/PlatformAdmin.php
@@ -84,6 +84,7 @@ class PlatformAdmin extends \tao_actions_SaSModule
                 foreach ($authType->getAuthProperties() as $authProperty) {
                     $values[$authProperty->getUri()] = $this->getRequest()->getParameter(\tao_helpers_Uri::encode($authProperty->getUri()));
                 }
+                $values = $authType->prepareAuthRequestValues($values);
 
                 $message = __('Undefined Instance can not be saved');
                 if (!$instance) {

--- a/controller/PlatformAdmin.php
+++ b/controller/PlatformAdmin.php
@@ -82,9 +82,9 @@ class PlatformAdmin extends \tao_actions_SaSModule
                 // according to the auth type we need to add properties for the authenticator
                 $values[PlatformService::PROPERTY_AUTH_TYPE] = $authType->getAuthClass()->getUri();
                 foreach ($authType->getAuthProperties() as $authProperty) {
-                    $values[$authProperty->getUri()] = $this->getRequest()->getParameter(\tao_helpers_Uri::encode($authProperty->getUri()));
+                    $values[$authProperty->getUri()]
+                         = $this->getPostParameter(\tao_helpers_Uri::encode($authProperty->getUri()));
                 }
-                $values = $authType->prepareAuthRequestValues($values);
 
                 $message = __('Undefined Instance can not be saved');
                 if (!$instance) {

--- a/manifest.php
+++ b/manifest.php
@@ -24,11 +24,11 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '2.0.0',
+    'version' => '2.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=6.0.0',
-        'tao' => '>=31.6.0'
+        'tao' => '>=35.2.2'
     ),
 	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoPublishingManager',
     'acl' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=6.0.0',
-        'tao' => '>=35.2.2'
+        'tao' => '>=31.6.0'
     ),
 	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoPublishingManager',
     'acl' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -247,6 +247,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.2.0');
         }
 
-        $this->skip('1.2.0', '2.0.0');
+        $this->skip('1.2.0', '2.0.1');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7326

Save BasicAuth password without htmlspecialchars prepare.
If we save 12345& password on the remote environments settings page this will be stored in the database as 12345&amp 

Steps to reproduce
1. Go to Remote environments page
2. Set up https://tciab-test.act.taocloud.org remote env (currently this password contain &)
3. Try run  Data Synchronization
4. Check response

Actual result: we get a response with http code 403
Expected result: we get a response with http code 200

