### PR TITLE
tao-6008/fix remote publishing delivery

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '2.0.1',
+    'version' => '2.0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=6.0.0',

--- a/model/PlatformService.php
+++ b/model/PlatformService.php
@@ -60,7 +60,7 @@ class PlatformService extends \tao_models_classes_ClassService
     {
         $platform = $this->getResource($platformId);
         $rootUrl = $platform->getUniquePropertyValue($this->getProperty(self::PROPERTY_ROOT_URL));
-        $rootUrl = rtrim($rootUrl,"/").'/';
+        $rootUrl = rtrim(trim($rootUrl), '/') . '/';
 
         /** @var PublishingAuthService $publishingAuthService */
         $publishingAuthService = $this->getServiceLocator()->get(PublishingAuthService::SERVICE_ID);
@@ -71,7 +71,7 @@ class PlatformService extends \tao_models_classes_ClassService
         $authenticator->setInstance($platform);
 
         $relUrl = $request->getUri()->__toString();
-        $absUrl = $rootUrl.ltrim($relUrl,'/');
+        $absUrl = $rootUrl . ltrim($relUrl, '/');
         $request = $request->withUri(new Uri($absUrl));
 
         return $authenticator->call($request, $clientOptions);

--- a/model/publishing/delivery/tasks/DeployTestEnvironments.php
+++ b/model/publishing/delivery/tasks/DeployTestEnvironments.php
@@ -84,6 +84,9 @@ class DeployTestEnvironments implements Action, ServiceLocatorAwareInterface, Ch
                 'instances' => $test->getUri(),
             ], \tao_helpers_File::createTempDir());
             $packagePath = $exportReport->getData();
+            if(is_array($packagePath) && isset($packagePath['path'])){
+                $packagePath = $packagePath['path'];
+            }
             $streamData = [[
                 'name'     => RestTest::REST_FILE_NAME,
                 'contents' => fopen($packagePath, 'rb'),

--- a/model/publishing/delivery/tasks/DeployTestEnvironments.php
+++ b/model/publishing/delivery/tasks/DeployTestEnvironments.php
@@ -48,8 +48,10 @@ class DeployTestEnvironments implements Action, ServiceLocatorAwareInterface, Ch
     use ChildTaskAwareTrait;
 
     /**
-     * 
-     * @param array $params
+     * @param array  $params
+     * @return \common_report_Report
+     * @throws \common_exception_Error
+     * @throws \common_exception_MissingParameter
      */
     public function __invoke($params) {
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -247,6 +247,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.2.0');
         }
 
-        $this->skip('1.2.0', '2.0.1');
+        $this->skip('1.2.0', '2.0.2');
     }
 }


### PR DESCRIPTION
issue: https://oat-sa.atlassian.net/browse/TAO-6008
Some changes in generating qti reports returns array instead of string.
How to test:
Configure remote environment. Publish delivery with sync.