### PR TITLE
Fix/double deliveries

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '2.1.1',
+    'version' => '2.1.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=6.0.0',

--- a/model/publishing/delivery/tasks/DeployTestEnvironments.php
+++ b/model/publishing/delivery/tasks/DeployTestEnvironments.php
@@ -98,8 +98,7 @@ class DeployTestEnvironments implements Action, ServiceLocatorAwareInterface, Ch
             ], [
                 'name'     => RestTest::REST_DELIVERY_PARAMS,
                 'contents' => json_encode([
-                    PublishingDeliveryService::ORIGIN_DELIVERY_ID_FIELD => $delivery->getUri(),
-                    OntologyRdfs::RDFS_LABEL => $delivery->getLabel()
+                    PublishingDeliveryService::ORIGIN_DELIVERY_ID_FIELD => $delivery->getUri()
                 ])
             ]];
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -247,6 +247,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.2.0');
         }
 
-        $this->skip('1.2.0', '2.1.1');
+        $this->skip('1.2.0', '2.1.2');
     }
 }


### PR DESCRIPTION
After remote publishing, we have a duplicate of a published delivery. It happens because we set a label to the custom property. That label always generating from a test label automatically. 