### PR TITLE
Feature/tao 10142/add dialog to publish to remote environments

### DIFF
--- a/controller/Publish.php
+++ b/controller/Publish.php
@@ -21,14 +21,12 @@
 
 namespace oat\taoPublishing\controller;
 
-use GuzzleHttp\Psr7\Request;
+use tao_helpers_Uri;
+use core_kernel_classes_Resource;
 use GuzzleHttp\Psr7\ServerRequest;
 use oat\tao\helpers\UrlHelper;
 use oat\taoPublishing\model\publishing\delivery\RemotePublishingService;
 use oat\taoPublishing\model\publishing\PublishingService;
-use Psr\Http\Message\RequestInterface;
-use tao_helpers_Uri;
-use core_kernel_classes_Resource;
 use oat\taoDeliveryRdf\model\NoTestsException;
 use oat\taoPublishing\view\form\WizardForm;
 use oat\generis\model\OntologyAwareTrait;

--- a/controller/Publish.php
+++ b/controller/Publish.php
@@ -21,6 +21,11 @@
 
 namespace oat\taoPublishing\controller;
 
+use GuzzleHttp\Psr7\Request;
+use oat\tao\helpers\UrlHelper;
+use oat\taoPublishing\model\publishing\PublishingService;
+use tao_helpers_Uri;
+use core_kernel_classes_Resource;
 use oat\taoDeliveryRdf\model\NoTestsException;
 use oat\taoPublishing\view\form\WizardForm;
 use oat\generis\model\OntologyAwareTrait;
@@ -61,5 +66,31 @@ class Publish extends \tao_actions_CommonModule {
         } catch (NoTestsException $e) {
             $this->setView('DeliveryMgmt/wizard_error.tpl');
         }
+    }
+
+    public function selectRemoteEnvironments()
+    {
+        $selectedDelivery = new core_kernel_classes_Resource(
+            tao_helpers_Uri::decode($this->getRequestParameter('uri'))
+        );
+
+        $environments = $this->getServiceLocator()
+            ->get(PublishingService::SERVICE_ID)
+            ->getEnvironments();
+
+        $submitUrl = $this->getServiceLocator()
+            ->get(UrlHelper::class)
+            ->buildUrl('publishToRemoteEnvironment', 'Publish', 'taoPublishing');
+
+        $this->setData('submit-url', $submitUrl);
+        $this->setData('delivery-uri', $selectedDelivery->getUri());
+        $this->setData('delivery-label', $selectedDelivery->getLabel());
+        $this->setData('remote-environments', $environments);
+        $this->setView('PublishToRemote/index.tpl');
+    }
+
+    public function publishToRemoteEnvironment()
+    {
+        $a = 'a';
     }
 }

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -34,7 +34,7 @@
 		<sections>
 			<section id="manage_delivery_assembly" name="Deliveries" url="/taoDeliveryRdf/DeliveryMgmt/index">
 				<actions>
-					<action id="delivery-remote-publish" name="Publish" url="/taoPublishing/Publish/selectRemoteEnvironments" context="instance" group="tree">
+					<action id="delivery-remote-publish" name="Publish To Remote" url="/taoPublishing/Publish/selectRemoteEnvironments" context="instance" group="tree">
 						<icon id="icon-external"/>
 					</action>
 				</actions>

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE structures SYSTEM "../doc/structures.dtd">
 <structures>
-    <!--<structure id="tests" name="Tests" level="1" group="main">-->
-        <!--<sections>-->
-            <!--<section id="manage_tests" name="Manage tests" url="/taoTests/Tests/index">-->
-                <!--<actions>-->
-                	<!--<action id="delivery-publish" name="Publish" url="/taoPublishing/Publish/wizard" group="tree" context="instance">-->
-                        <!--<icon id="icon-magicwand"/>-->
-                    <!--</action>-->
-                <!--</actions>-->
-            <!--</section>-->
-        <!--</sections>-->
-    <!--</structure>-->
 	<structure id="settings" name="Settings" level="11" group="invisible">
 		<description />
 		<sections>
@@ -37,6 +26,17 @@
 					<action id="platform-new" name="Add Platform" url="/taoPublishing/PlatformAdmin/addInstanceForm" context="class" group="tree">
                         <icon id="icon-add"/>
                     </action>
+				</actions>
+			</section>
+		</sections>
+	</structure>
+	<structure id="delivery" name="Deliveries" level="4" group="main">
+		<sections>
+			<section id="manage_delivery_assembly" name="Deliveries" url="/taoDeliveryRdf/DeliveryMgmt/index">
+				<actions>
+					<action id="delivery-remote-publish" name="Publish" url="/taoPublishing/Publish/selectRemoteEnvironments" context="instance" group="tree">
+						<icon id="icon-external"/>
+					</action>
 				</actions>
 			</section>
 		</sections>

--- a/manifest.php
+++ b/manifest.php
@@ -24,10 +24,10 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '2.3.0',
+    'version' => '2.4.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'taoDeliveryRdf' => '>=11.7.0',
+        'taoDeliveryRdf' => '>=12.0.0',
         'tao' => '>=31.6.0',
         'taoQtiTest' => '>=38.13.0',
     ),

--- a/model/publishing/delivery/PublishingDeliveryService.php
+++ b/model/publishing/delivery/PublishingDeliveryService.php
@@ -75,7 +75,16 @@ class PublishingDeliveryService extends ConfigurableService
         foreach ($environments as $env) {
             if ($this->checkActionForEnvironment(DeliveryCreatedEvent::class, $env)) {
                 $callBackTask = new CallbackTask($taskLog->getId(), $taskLog->getOwner());
-                $task = $queueDispatcher->createTask(new DeployTestEnvironments(), [$test->getUri(), $env->getUri(), $delivery->getUri()], __('Publishing %s to remote env %s', $delivery->getLabel(), $env->getLabel()), $callBackTask);
+                $task = $queueDispatcher->createTask(
+                    new DeployTestEnvironments(),
+                    [$test->getUri(), $env->getUri(), $delivery->getUri()],
+                    __(
+                        'Publishing %s to remote env %s',
+                        $delivery->getLabel(),
+                        $env->getLabel()
+                    ),
+                    $callBackTask
+                );
                 $message = DeployTestEnvironments::class . "task created; Task id: " . $task->getId();
                 $report->add(\common_report_Report::createSuccess($message));
                 $this->logNotice($message);

--- a/model/publishing/delivery/RemotePublishingService.php
+++ b/model/publishing/delivery/RemotePublishingService.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\taoPublishing\model\publishing\delivery;
+
+use Throwable;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\taskQueue\QueueDispatcherInterface;
+use oat\tao\model\taskQueue\Task\CallbackTaskInterface;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoPublishing\model\publishing\delivery\tasks\DeployTestEnvironments;
+use oat\taoPublishing\model\publishing\exception\PublishingFailedException;
+
+class RemotePublishingService extends ConfigurableService
+{
+    use OntologyAwareTrait;
+
+    /** @var string */
+    private $deliveryUri;
+
+    /** @var string */
+    private $testUri;
+
+    /** @var QueueDispatcherInterface */
+    private $queueDispatcher;
+
+    /**
+     * @param string $deliveryUri
+     * @param array $environments
+     * @return CallbackTaskInterface[]
+     * @throws PublishingFailedException
+     */
+    public function publishDeliveryToEnvironments(string $deliveryUri, array $environments): array
+    {
+        $this->deliveryUri = $deliveryUri;
+        $this->testUri = $this->getOriginTestUri($deliveryUri);
+        $this->queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
+        $deliveryLabel = $this->getResource($deliveryUri)->getLabel();
+
+        $tasks = [];
+        foreach ($environments as $environmentUri) {
+            try {
+                $tasks[] = $this->publishToEnvironment($environmentUri, $deliveryLabel);
+            } catch (Throwable $e) {
+                $this->logError(
+                    sprintf(
+                        '[REMOTE_PUBLISHING] Publishing of delivery %s to remote environment %s failed. Error:  %s',
+                        $deliveryUri,
+                        $environmentUri,
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+
+        return $tasks;
+    }
+
+    private function getOriginTestUri(string $deliveryUri): string
+    {
+        $testProperty = $this->getProperty(DeliveryAssemblyService::PROPERTY_ORIGIN);
+        $deliveryResource = $this->getResource($deliveryUri);
+        $testResource = $deliveryResource->getOnePropertyValue($testProperty);
+        if (!$testResource instanceof \core_kernel_classes_Resource) {
+            throw new PublishingFailedException("Origin test property not found for delivery: {$deliveryUri}");
+        }
+
+        return $testResource->getUri();
+    }
+
+    private function publishToEnvironment(string $environmentUri, string $deliveryLabel): CallbackTaskInterface
+    {
+        $params = [
+            $this->testUri,
+            $environmentUri,
+            $this->deliveryUri
+        ];
+        $environmentLabel = $this->getResource($environmentUri)->getLabel();
+        $message = __("Publishing %s to remote env %s", $deliveryLabel, $environmentLabel);
+
+        return $this->queueDispatcher->createTask(new DeployTestEnvironments(), $params, $message);
+    }
+}

--- a/model/publishing/delivery/RemotePublishingService.php
+++ b/model/publishing/delivery/RemotePublishingService.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace oat\taoPublishing\model\publishing\delivery;
 
+use oat\taoPublishing\model\publishing\exception\PublishingInvalidArgumentException;
 use Throwable;
 use core_kernel_classes_Resource;
 use oat\generis\model\OntologyAwareTrait;
@@ -52,14 +53,14 @@ class RemotePublishingService extends ConfigurableService
      * @param array $environments
      * @return CallbackTaskInterface[]
      * @throws PublishingFailedException
+     * @throws PublishingInvalidArgumentException
      */
     public function publishDeliveryToEnvironments(string $deliveryUri, array $environments): array
     {
-        $this->deliveryUri = $deliveryUri;
-        $this->deliveryResource = $this->getResource($deliveryUri);
-        $this->testUri = $this->getOriginTestUri();
-
         $tasks = [];
+        $this->deliveryUri = $deliveryUri;
+        $this->deliveryResource = $this->getDeliveryResource($deliveryUri);
+        $this->testUri = $this->getOriginTestUri();
         $this->queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
         foreach ($environments as $environmentUri) {
             try {
@@ -95,6 +96,12 @@ class RemotePublishingService extends ConfigurableService
 
     private function publishToEnvironment(core_kernel_classes_Resource $environment): CallbackTaskInterface
     {
+        if (!$environment->exists()) {
+            throw new PublishingInvalidArgumentException(
+                __(sprintf('Remote environment with URI "%s" does not exist.', $environment->getUri()))
+            );
+        }
+
         $params = [
             $this->testUri,
             $environment->getUri(),
@@ -103,5 +110,17 @@ class RemotePublishingService extends ConfigurableService
         $message = __("Publishing %s to remote env %s", $this->deliveryResource->getLabel(), $environment->getLabel());
 
         return $this->queueDispatcher->createTask(new DeployTestEnvironments(), $params, $message);
+    }
+
+    private function getDeliveryResource(string $deliveryUri): core_kernel_classes_Resource
+    {
+        $deliveryResource = $this->getResource($deliveryUri);
+        if (!$deliveryResource->exists()) {
+            throw new PublishingInvalidArgumentException(
+                sprintf("Delivery resource with URI '%s' does not exist.", $deliveryUri)
+            );
+        }
+
+        return $deliveryResource;
     }
 }

--- a/model/publishing/delivery/listeners/DeliveryEventsListener.php
+++ b/model/publishing/delivery/listeners/DeliveryEventsListener.php
@@ -38,7 +38,7 @@ class DeliveryEventsListener extends ConfigurableService
             $testBackupService = $this->getServiceLocator()->get(TestBackupService::class);
             $file = $testBackupService->backupDeliveryTestPackage(
                 $event->getDeliveryUri(),
-                $event->getOriginTest()->getUri()
+                $event->getOriginTestUri()
             );
             $this->storeQtiTestBackupPath($event->getDeliveryUri(), $file->getPrefix());
         } catch (Throwable $e) {

--- a/model/publishing/exception/PublishingFailedException.php
+++ b/model/publishing/exception/PublishingFailedException.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\taoPublishing\model\publishing\exception;
+
+use common_Exception;
+
+class PublishingFailedException extends common_Exception
+{
+}

--- a/model/publishing/exception/PublishingInvalidArgumentException.php
+++ b/model/publishing/exception/PublishingInvalidArgumentException.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\taoPublishing\model\publishing\exception;
+
+use common_exception_ClientException;
+
+class PublishingInvalidArgumentException extends common_exception_ClientException
+{
+    public function getUserMessage()
+    {
+        return $this->getMessage();
+    }
+}

--- a/test/unit/model/publishing/delivery/RemotePublishingServiceTest.php
+++ b/test/unit/model/publishing/delivery/RemotePublishingServiceTest.php
@@ -72,6 +72,8 @@ class RemotePublishingServiceTest extends TestCase
 
         $this->mockOriginTestProperty();
         $deliveryResourceMock = $this->getDeliveryResourceMock(null);
+        $deliveryResourceMock->method('exists')
+            ->willReturn(true);
 
         $this->ontologyMock
             ->method('getResource')
@@ -92,6 +94,8 @@ class RemotePublishingServiceTest extends TestCase
         $this->mockOriginTestProperty();
         $testResourceMock = $this->getTestResourceMock($testUri);
         $deliveryResourceMock = $this->getDeliveryResourceMock($testResourceMock);
+        $deliveryResourceMock->method('exists')
+            ->willReturn(true);
         $environmentMock = $this->createMock(core_kernel_classes_Resource::class);
 
         $this->ontologyMock
@@ -120,8 +124,14 @@ class RemotePublishingServiceTest extends TestCase
         $this->mockOriginTestProperty();
         $testResourceMock = $this->getTestResourceMock($testUri);
         $deliveryResourceMock = $this->getDeliveryResourceMock($testResourceMock);
+        $deliveryResourceMock->method('exists')
+            ->willReturn(true);
         $environmentMock1 = $this->createMock(core_kernel_classes_Resource::class);
+        $environmentMock1->method('exists')
+            ->willReturn(true);
         $environmentMock2 = $this->createMock(core_kernel_classes_Resource::class);
+        $environmentMock2->method('exists')
+            ->willReturn(true);
 
         $this->ontologyMock
             ->method('getResource')

--- a/test/unit/model/publishing/delivery/RemotePublishingServiceTest.php
+++ b/test/unit/model/publishing/delivery/RemotePublishingServiceTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\taoPublishing\test\unit\model\publishing\delivery;
+
+use common_exception_Error;
+use core_kernel_classes_Resource;
+use core_kernel_classes_Property;
+use oat\generis\model\data\Ontology;
+use oat\generis\test\MockObject;
+use oat\oatbox\log\LoggerService;
+use oat\tao\model\taskQueue\QueueDispatcherInterface;
+use oat\tao\model\taskQueue\Task\CallbackTaskInterface;
+use oat\taoPublishing\model\publishing\delivery\RemotePublishingService;
+use oat\generis\test\TestCase;
+use oat\taoPublishing\model\publishing\exception\PublishingFailedException;
+
+class RemotePublishingServiceTest extends TestCase
+{
+    /** RemotePublishingService */
+    private $subject;
+
+    /** @var Ontology|MockObject */
+    private $ontologyMock;
+
+    /** @var LoggerService */
+    private $loggerMock;
+
+    /** @var QueueDispatcherInterface|MockObject */
+    private $queueDispatcherMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ontologyMock =  $this->createMock(Ontology::class);
+        $this->loggerMock = $this->createMock(LoggerService::class);
+        $this->queueDispatcherMock = $this->createMock(QueueDispatcherInterface::class);
+        $serviceLocatorMock = $this->getServiceLocatorMock(
+            [
+                QueueDispatcherInterface::SERVICE_ID => $this->queueDispatcherMock,
+                LoggerService::SERVICE_ID => $this->loggerMock
+            ]
+        );
+
+        $this->subject = new RemotePublishingService();
+        $this->subject->setModel($this->ontologyMock);
+        $this->subject->setServiceLocator($serviceLocatorMock);
+    }
+
+    public function testPublishDeliveryToEnvironments_WhenDeliveryDoesNotHaveOriginTest_ThrowsException(): void
+    {
+        $deliveryUri = 'FAKE_DELIVERY_URI';
+        $environments = ['FAKE_ENVIRONMENT_URI'];
+
+        $this->mockOriginTestProperty();
+        $deliveryResourceMock = $this->getDeliveryResourceMock(null);
+
+        $this->ontologyMock
+            ->method('getResource')
+            ->with($deliveryUri)
+            ->willReturn($deliveryResourceMock);
+
+        self::expectException(PublishingFailedException::class);
+
+        $this->subject->publishDeliveryToEnvironments($deliveryUri, $environments);
+    }
+
+    public function testPublishDeliveryToEnvironments_WhenPublicationToEnvFailed_LogsError(): void
+    {
+        $deliveryUri = 'FAKE_DELIVERY_URI';
+        $testUri = 'FAKE_TEST_URI';
+        $environments = ['FAKE_ENVIRONMENT_URI'];
+
+        $this->mockOriginTestProperty();
+        $testResourceMock = $this->getTestResourceMock($testUri);
+        $deliveryResourceMock = $this->getDeliveryResourceMock($testResourceMock);
+        $environmentMock = $this->createMock(core_kernel_classes_Resource::class);
+
+        $this->ontologyMock
+            ->method('getResource')
+            ->withConsecutive([$deliveryUri], ['FAKE_ENVIRONMENT_URI'])
+            ->willReturnOnConsecutiveCalls($deliveryResourceMock, $environmentMock);
+
+        $this->queueDispatcherMock
+            ->method('createTask')
+            ->willThrowException(new common_exception_Error('DUMMY DISPATCHER EXCEPTION MESSAGE'));
+
+        $this->loggerMock->expects(self::once())
+            ->method('error');
+
+        $tasks = $this->subject->publishDeliveryToEnvironments($deliveryUri, $environments);
+        self::assertCount(0, $tasks, 'Method must return correct number of created tasks.');
+    }
+
+    public function testPublishDeliveryToEnvironments_ReturnsListOfCreatedTasks(): void
+    {
+        $deliveryUri = 'FAKE_DELIVERY_URI';
+        $testUri = 'FAKE_TEST_URI';
+        $environments = ['FAKE_ENVIRONMENT_URI_1', 'FAKE_ENVIRONMENT_URI_2'];
+        $expectedTasksAmount = 2;
+
+        $this->mockOriginTestProperty();
+        $testResourceMock = $this->getTestResourceMock($testUri);
+        $deliveryResourceMock = $this->getDeliveryResourceMock($testResourceMock);
+        $environmentMock1 = $this->createMock(core_kernel_classes_Resource::class);
+        $environmentMock2 = $this->createMock(core_kernel_classes_Resource::class);
+
+        $this->ontologyMock
+            ->method('getResource')
+            ->willReturnOnConsecutiveCalls($deliveryResourceMock, $environmentMock1, $environmentMock2);
+
+        $task1 = $this->createMock(CallbackTaskInterface::class);
+        $task2 = $this->createMock(CallbackTaskInterface::class);
+        $this->queueDispatcherMock
+            ->method('createTask')
+            ->willReturnOnConsecutiveCalls($task1, $task2);
+
+        $tasks = $this->subject->publishDeliveryToEnvironments($deliveryUri, $environments);
+
+        self::assertCount($expectedTasksAmount, $tasks, 'Method must return expected number of created tasks.');
+        self::assertInstanceOf(CallbackTaskInterface::class, $tasks[0]);
+        self::assertInstanceOf(CallbackTaskInterface::class, $tasks[1]);
+    }
+
+    private function mockOriginTestProperty(): void
+    {
+        $propertyOriginMock = $this->createMock(core_kernel_classes_Property::class);
+        $this->ontologyMock
+            ->method('getProperty')
+            ->willReturn($propertyOriginMock);
+    }
+
+    /**
+     * @param string $testUri
+     * @return core_kernel_classes_Resource|MockObject
+     */
+    private function getTestResourceMock(string $testUri): core_kernel_classes_Resource
+    {
+        $testResourceMock = $this->createMock(core_kernel_classes_Resource::class);
+        $testResourceMock->method('getUri')
+            ->willReturn($testUri);
+
+        return $testResourceMock;
+    }
+
+    /**
+     * @param mixed $expectedOriginTestValue
+     * @return core_kernel_classes_Resource|MockObject
+     */
+    private function getDeliveryResourceMock($expectedOriginTestValue): core_kernel_classes_Resource
+    {
+        $deliveryResourceMock = $this->createMock(core_kernel_classes_Resource::class);
+        $deliveryResourceMock->method('getOnePropertyValue')
+            ->willReturn($expectedOriginTestValue);
+
+        return $deliveryResourceMock;
+    }
+}
+

--- a/views/js/controller/Publish/selectRemoteEnvironments.js
+++ b/views/js/controller/Publish/selectRemoteEnvironments.js
@@ -1,0 +1,87 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020  (original work) Open Assessment Technologies SA;
+ */
+
+define([
+    'jquery',
+    'i18n',
+    'layout/actions',
+    'ui/feedback',
+    'ui/taskQueue/taskQueue',
+    'layout/loading-bar'
+], function (
+    $,
+    __,
+    actionManager,
+    feedback,
+    taskQueue,
+    loadingBar
+) {
+    'use strict';
+
+    /**
+     * wrapped the old jstree API used to refresh the tree and optionally select a resource
+     * @param {String} [uriResource] - the uri resource node to be selected
+     */
+    const refreshTree = function refreshTree(uriResource) {
+        actionManager.trigger('refresh', {
+            uri: uriResource
+        });
+    };
+
+    return {
+        start: function start() {
+            const $publishBtn = $('#publish-to-remote');
+            const $form = $('#publish-remote');
+            const $treePublishButton = $('#delivery-remote-publish');
+
+            $form.on('submit', function (e) {
+                e.preventDefault();
+
+                loadingBar.start();
+                taskQueue.pollAllStop();
+                taskQueue
+                    .create($form.prop('action'), $form.serializeArray())
+                    .then(function(result) {
+                        const tasksCount = result['extra']['allTasks'].length + 1;
+                        const message = __('<strong> %s </strong> task(s) have been moved to the background.', tasksCount);
+
+                        feedback(null, {
+                            encodeHtml: false,
+                            timeout: { info: 8000 }
+                        }).info(message);
+
+                        // updating tasks in the background tasks
+                        taskQueue.pollAll(true);
+                        refreshTree($('#selected-delivery-uri').val());
+                        loadingBar.stop();
+                    }).catch(function(err) {
+                        //in case of error display it and continue task queue activity
+                        taskQueue.pollAll();
+                        loadingBar.stop();
+                        //format and display error message to user
+                        feedback().error(err.message);
+                        // refreshTree();
+                        $treePublishButton.click();
+                    });
+
+                return false;
+            });
+            $publishBtn.removeClass('hidden');
+        }
+    }
+});

--- a/views/js/controller/routes.js
+++ b/views/js/controller/routes.js
@@ -6,6 +6,11 @@ define(function(){
                 'addInstanceForm': 'controller/PlatformAdmin/editor',
                 'editInstance': 'controller/PlatformAdmin/editor'
             }
+        },
+        'Publish': {
+            'actions': {
+                'selectRemoteEnvironments': 'controller/Publish/selectRemoteEnvironments',
+            }
         }
     };
 });

--- a/views/templates/PublishToRemote/index.tpl
+++ b/views/templates/PublishToRemote/index.tpl
@@ -17,14 +17,14 @@ use oat\tao\helpers\Template;
 
                 <?php if (count(get_data('remote-environments')) > 0) :?>
                     <h3><?= __('Remote environment(s)')?></h3>
-                    <div class="remotePublishingEnvironments">
-                        <?php foreach (get_data('remote-environments') as $environment) :?>
-                            <p>
-                                <input type="checkbox" name="remote-environment[]" value="<?= $environment->getUri();?>">
-                                <label><?= $environment->getLabel();?></label>
-                            </p>
+                    <ul class="plain">
+                        <?php foreach (get_data('remote-environments') as $index => $environment) :?>
+                            <li>
+                                <input type="checkbox" name="remote-environments[]" value="<?= $environment->getUri();?>" id="remote-environment-<?= $index ?>">
+                                <label for="remote-environment-<?= $index ?>"><?= $environment->getLabel();?></label>
+                            </li>
                         <?php endforeach;?>
-                    </div>
+                    </ul>
                     <div class="form-toolbar">
                         <button type="submit" name="Publish" id="Publish" class="form-submitter btn-success small" value="Publish"><span class="icon-external"></span> <?= __('Publish')?></button>
                     </div>

--- a/views/templates/PublishToRemote/index.tpl
+++ b/views/templates/PublishToRemote/index.tpl
@@ -1,0 +1,40 @@
+<?php
+use oat\tao\helpers\Template;
+?>
+
+
+<div class="main-container flex-container-main-form">
+    <h2><?=__('Publish "%s"', _dh(get_data('delivery-label')))?></h2>
+    <div id="form-container" class="form-content">
+        <div class="xhtml_form">
+            <form action="<?= get_data('submit-url'); ?>">
+                <input type="hidden" value="<?= get_data('delivery-uri') ?>" name="delivery-uri">
+                <?php if (has_data('warning')) :?>
+                <div class='feedback-warning'>
+                    <?= get_data('warning')?>
+                </div>
+                <?php endif;?>
+
+                <?php if (count(get_data('remote-environments')) > 0) :?>
+                    <h3><?= __('Remote environment(s)')?></h3>
+                    <div class="remotePublishingEnvironments">
+                        <?php foreach (get_data('remote-environments') as $environment) :?>
+                            <p>
+                                <input type="checkbox" name="remote-environment[]" value="<?= $environment->getUri();?>">
+                                <label><?= $environment->getLabel();?></label>
+                            </p>
+                        <?php endforeach;?>
+                    </div>
+                    <div class="form-toolbar">
+                        <button type="submit" name="Publish" id="Publish" class="form-submitter btn-success small" value="Publish"><span class="icon-external"></span> <?= __('Publish')?></button>
+                    </div>
+                <?php else:?>
+                    <em><?= __('No Remote environments defined')?></em>
+                <?php endif;?>
+            </form>
+        </div>
+    </div>
+</div>
+<?php
+Template::inc('footer.tpl', 'tao')
+?>

--- a/views/templates/PublishToRemote/index.tpl
+++ b/views/templates/PublishToRemote/index.tpl
@@ -7,8 +7,8 @@ use oat\tao\helpers\Template;
     <h2><?=__('Publish "%s"', _dh(get_data('delivery-label')))?></h2>
     <div id="form-container" class="form-content">
         <div class="xhtml_form">
-            <form action="<?= get_data('submit-url'); ?>">
-                <input type="hidden" value="<?= get_data('delivery-uri') ?>" name="delivery-uri">
+            <form action="<?= get_data('submit-url'); ?>" id="publish-remote">
+                <input type="hidden" value="<?= get_data('delivery-uri') ?>" name="delivery-uri" id="selected-delivery-uri">
                 <?php if (has_data('warning')) :?>
                 <div class='feedback-warning'>
                     <?= get_data('warning')?>
@@ -26,7 +26,7 @@ use oat\tao\helpers\Template;
                         <?php endforeach;?>
                     </ul>
                     <div class="form-toolbar">
-                        <button type="submit" name="Publish" id="Publish" class="form-submitter btn-success small" value="Publish"><span class="icon-external"></span> <?= __('Publish')?></button>
+                        <button type="submit" name="Publish" id="publish-to-remote" class="form-submitter btn-success small hidden" value="Publish"><span class="icon-external"></span> <?= __('Publish')?></button>
                     </div>
                 <?php else:?>
                     <em><?= __('No Remote environments defined')?></em>


### PR DESCRIPTION
Jira ticket: https://oat-sa.atlassian.net/browse/TAO-10142

The goal of this development is to add a new action "Publish To Remote" with possibility to publish delivery to selected remote environments any time. 

How to test:
- Add remote environment(s) in "Settings -> Remote Environments"
- Create local delivery (do not check `Sync to remote environments` on new delivery form)
- Open newly created delivery
- New button "Publish To Remote" should appear in actions panel
- Click "Publish To Remote" -> select remote environment(s) -> press "Publish" button
- Check selected remote environments, new delivery must be created (may take some time depending on delivery size)

*Note: At the moment it uses old task (for backward compatibility) and exports QTI test package when task is executed. This functionality will be optimized in future when old "remote publishing" functionality will be deleted.