### PR TITLE
GUI for the task (background tasks in the backoffice)

### DIFF
--- a/views/js/controller/Publish/selectRemoteEnvironments.js
+++ b/views/js/controller/Publish/selectRemoteEnvironments.js
@@ -18,23 +18,15 @@
 
 define([
     'jquery',
-    'lodash',
     'i18n',
-    'util/url',
     'layout/actions',
-    'provider/resources',
-    'ui/destination/selector',
     'ui/feedback',
     'ui/taskQueue/taskQueue',
     'layout/loading-bar'
 ], function (
     $,
-    _,
     __,
-    urlHelper,
     actionManager,
-    resourceProviderFactory,
-    destinationSelectorFactory,
     feedback,
     taskQueue,
     loadingBar
@@ -45,7 +37,7 @@ define([
      * wrapped the old jstree API used to refresh the tree and optionally select a resource
      * @param {String} [uriResource] - the uri resource node to be selected
      */
-    var refreshTree = function refreshTree(uriResource) {
+    const refreshTree = function refreshTree(uriResource) {
         actionManager.trigger('refresh', {
             uri: uriResource
         });
@@ -67,13 +59,12 @@ define([
                     .then(function(result) {
                         const tasksCount = result['extra']['allTasks'].length + 1;
                         const message = __('<strong> %s </strong> task(s) have been moved to the background.', tasksCount);
-                        const infoBox = feedback(null, {
+
+                        feedback(null, {
                             encodeHtml: false,
                             timeout: { info: 8000 }
                         }).info(message);
 
-                        // ui effects
-                        taskQueue.trigger('taskcreated', { sourceDom: infoBox.getElement() });
                         // updating tasks in the background tasks
                         taskQueue.pollAll(true);
                         refreshTree($('#selected-delivery-uri').val());

--- a/views/js/controller/Publish/selectRemoteEnvironments.js
+++ b/views/js/controller/Publish/selectRemoteEnvironments.js
@@ -1,0 +1,96 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020  (original work) Open Assessment Technologies SA;
+ */
+
+define([
+    'jquery',
+    'lodash',
+    'i18n',
+    'util/url',
+    'layout/actions',
+    'provider/resources',
+    'ui/destination/selector',
+    'ui/feedback',
+    'ui/taskQueue/taskQueue',
+    'layout/loading-bar'
+], function (
+    $,
+    _,
+    __,
+    urlHelper,
+    actionManager,
+    resourceProviderFactory,
+    destinationSelectorFactory,
+    feedback,
+    taskQueue,
+    loadingBar
+) {
+    'use strict';
+
+    /**
+     * wrapped the old jstree API used to refresh the tree and optionally select a resource
+     * @param {String} [uriResource] - the uri resource node to be selected
+     */
+    var refreshTree = function refreshTree(uriResource) {
+        actionManager.trigger('refresh', {
+            uri: uriResource
+        });
+    };
+
+    return {
+        start: function start() {
+            const $publishBtn = $('#publish-to-remote');
+            const $form = $('#publish-remote');
+            const $treePublishButton = $('#delivery-remote-publish');
+
+            $form.on('submit', function (e) {
+                e.preventDefault();
+
+                loadingBar.start();
+                taskQueue.pollAllStop();
+                taskQueue
+                    .create($form.prop('action'), $form.serializeArray())
+                    .then(function(result) {
+                        const tasksCount = result['extra']['allTasks'].length + 1;
+                        const message = __('<strong> %s </strong> task(s) have been moved to the background.', tasksCount);
+                        const infoBox = feedback(null, {
+                            encodeHtml: false,
+                            timeout: { info: 8000 }
+                        }).info(message);
+
+                        // ui effects
+                        taskQueue.trigger('taskcreated', { sourceDom: infoBox.getElement() });
+                        // updating tasks in the background tasks
+                        taskQueue.pollAll(true);
+                        refreshTree($('#selected-delivery-uri').val());
+                        loadingBar.stop();
+                    }).catch(function(err) {
+                        //in case of error display it and continue task queue activity
+                        taskQueue.pollAll();
+                        loadingBar.stop();
+                        //format and display error message to user
+                        feedback().error(err.message);
+                        // refreshTree();
+                        $treePublishButton.click();
+                    });
+
+                return false;
+            });
+            $publishBtn.removeClass('hidden');
+        }
+    }
+});

--- a/views/js/controller/routes.js
+++ b/views/js/controller/routes.js
@@ -6,6 +6,11 @@ define(function(){
                 'addInstanceForm': 'controller/PlatformAdmin/editor',
                 'editInstance': 'controller/PlatformAdmin/editor'
             }
+        },
+        'Publish': {
+            'actions': {
+                'selectRemoteEnvironments': 'controller/Publish/selectRemoteEnvironments',
+            }
         }
     };
 });

--- a/views/templates/PublishToRemote/index.tpl
+++ b/views/templates/PublishToRemote/index.tpl
@@ -7,8 +7,8 @@ use oat\tao\helpers\Template;
     <h2><?=__('Publish "%s"', _dh(get_data('delivery-label')))?></h2>
     <div id="form-container" class="form-content">
         <div class="xhtml_form">
-            <form action="<?= get_data('submit-url'); ?>">
-                <input type="hidden" value="<?= get_data('delivery-uri') ?>" name="delivery-uri">
+            <form action="<?= get_data('submit-url'); ?>" id="publish-remote">
+                <input type="hidden" value="<?= get_data('delivery-uri') ?>" name="delivery-uri" id="selected-delivery-uri">
                 <?php if (has_data('warning')) :?>
                 <div class='feedback-warning'>
                     <?= get_data('warning')?>
@@ -26,7 +26,7 @@ use oat\tao\helpers\Template;
                         <?php endforeach;?>
                     </ul>
                     <div class="form-toolbar">
-                        <button type="submit" name="Publish" id="Publish" class="form-submitter btn-success small" value="Publish"><span class="icon-external"></span> <?= __('Publish')?></button>
+                        <button type="submit" name="Publish" id="publish-to-remote" class="form-submitter btn-success small hidden" value="Publish"><span class="icon-external"></span> <?= __('Publish')?></button>
                     </div>
                 <?php else:?>
                     <em><?= __('No Remote environments defined')?></em>


### PR DESCRIPTION
Jira ticket: https://oat-sa.atlassian.net/browse/TAO-10142

This PR is a GUI part of the task:
click on Publish button:
- if no remote servers selected: error message
- if remote servers selected: visualisation of the task adding to the queue + updated background tasks without page reloading.

How to test:
- Add remote environment(s) in "Settings -> Remote Environments"
- Create local delivery (do not check `Sync to remote environments` on new delivery form)
- Open newly created delivery
- New button "Publish To Remote" should appear in actions panel
- Click "Publish To Remote" -> select remote environment(s) -> press "Publish" button
- Check selected remote environments, new delivery must be created (may take some time depending on delivery size)