### PR TITLE
Fix/bundle javascript with babel

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '3.0.0',
+    'version' => '3.0.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=12.0.0',

--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -31,7 +31,8 @@ module.exports = function(grunt) {
                     outputDir : 'loader',
                     bundles : [{
                         name : 'taoPublishing',
-                        default : true
+                        default : true,
+                        babel : true
                     }]
                 }
             }


### PR DESCRIPTION
Related to : release

Changes : 
 - add Babel to the bundle configuration to support JavaScript code written with ES2015+ 

What's wrong : 
 - some code in this extension was written with ES2015+  feature but the build wasn't configured to support it

Fix : 
 - added `babel: true` to the bundle configuration

How to test : 
 - `cd tao/views/build && npm ci && npx grunt taopublishing bundle`, if the command succeed the issue is fixed