### PR TITLE
Fix/tao 10137/fix remote publishing when using s3

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '3.0.1',
+    'version' => '3.0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=12.0.0',

--- a/model/publishing/delivery/tasks/DeployTestEnvironments.php
+++ b/model/publishing/delivery/tasks/DeployTestEnvironments.php
@@ -91,7 +91,8 @@ class DeployTestEnvironments implements Action, ServiceLocatorAwareInterface, Ch
             $streamData = [
                 [
                     'name' => RestTest::REST_FILE_NAME,
-                    'contents' => $qtiPackageFile->readStream(),
+                    'filename' => RestTest::REST_FILE_NAME,
+                    'contents' => $qtiPackageFile->readPsrStream(),
                 ],
                 [
                     'name' => RestTest::REST_IMPORTER_ID,


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TAO-10137

The issue: 
When publishing from TAO installed on AWS environment (QTI package backup stored in S3) to remote environment request fails. On target environment API endpoint `/taoDeliveryRdf/RestTest/compileDeferred` doesn't see uploaded file.

It happens because guzzle adds `filename` request property only when uploading local file (as it was before changes in this ticket) - https://github.com/guzzle/psr7/blob/master/src/MultipartStream.php#L92

Fix:
Added `filename` request property explicitly.