### PR TITLE
Fix/tao 10137/validate api params

### DIFF
--- a/controller/api/Deliveries.php
+++ b/controller/api/Deliveries.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace oat\taoPublishing\controller\api;
 
 use common_exception_BadRequest;
-use common_exception_MissingParameter;
 use common_exception_NotImplemented;
 use common_exception_RestApi;
 use Exception;

--- a/controller/api/Deliveries.php
+++ b/controller/api/Deliveries.php
@@ -192,7 +192,7 @@ class Deliveries extends \tao_actions_RestController
                 throw new common_exception_NotImplemented('Only POST method is accepted to publish deliveries');
             }
             $requestData = $request->getParsedBody();
-            $deliveryUri = $this->getDeliveryParameter($requestData);
+            $deliveryUri = $this->getDeliveryUriParameter($requestData);
             $remoteEnvironmentUris = $this->getRemoteEnvironmentsParameter($requestData);
 
             /** @var RemotePublishingService $remotePublishingService */
@@ -212,9 +212,9 @@ class Deliveries extends \tao_actions_RestController
         }
     }
 
-    private function getDeliveryParameter(?array $requestData): string
+    private function getDeliveryUriParameter(?array $requestData): string
     {
-        if (!array_key_exists(self::REST_DELIVERY_URI, $requestData)) {
+        if (!is_array($requestData) || !array_key_exists(self::REST_DELIVERY_URI, $requestData)) {
             throw new common_exception_RestApi(__('Missing required parameter: `%s`', self::REST_DELIVERY_URI), 400);
         }
         if (empty($requestData[self::REST_DELIVERY_URI])) {
@@ -226,7 +226,7 @@ class Deliveries extends \tao_actions_RestController
 
     private function getRemoteEnvironmentsParameter(?array $requestData): array
     {
-        if (!array_key_exists(self::REST_REMOTE_ENVIRONMENTS, $requestData)) {
+        if (!is_array($requestData) || !array_key_exists(self::REST_REMOTE_ENVIRONMENTS, $requestData)) {
             throw new common_exception_RestApi(__('Missing required parameter: `%s`', self::REST_REMOTE_ENVIRONMENTS), 400);
         }
         $environments = $requestData[self::REST_REMOTE_ENVIRONMENTS];

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '3.0.1',
+    'version' => '3.0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=12.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '3.0.2',
+    'version' => '3.0.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=12.0.0',

--- a/test/unit/model/publishing/delivery/RemotePublishingServiceTest.php
+++ b/test/unit/model/publishing/delivery/RemotePublishingServiceTest.php
@@ -144,7 +144,7 @@ class RemotePublishingServiceTest extends TestCase
         $testResourceMock = $this->getTestResourceMock($testUri);
         $deliveryExists = true;
         $deliveryResourceMock = $this->getDeliveryResourceMock($testResourceMock, $deliveryExists);
-        $environmentMock = $this->createMock(core_kernel_classes_Resource::class);
+        $environmentMock = $this->getRemoteEnvironmentMock(true, true);
 
         $this->ontologyMock
             ->method('getResource')
@@ -162,12 +162,11 @@ class RemotePublishingServiceTest extends TestCase
         self::assertCount(0, $tasks, 'Method must return correct number of created tasks.');
     }
 
-    public function testPublishDeliveryToEnvironments_EnvironmentDoesNotExist(): void
+    public function testPublishDeliveryToEnvironments_EnvironmentDoesNotExist_ThrowsException(): void
     {
         $deliveryUri = 'FAKE_DELIVERY_URI';
         $testUri = 'FAKE_TEST_URI';
         $environments = ['FAKE_ENVIRONMENT_URI_1', 'FAKE_ENVIRONMENT_URI_2'];
-        $expectedTasksAmount = 1;
 
         $testResourceMock = $this->getTestResourceMock($testUri);
         $deliveryExists = true;
@@ -175,30 +174,23 @@ class RemotePublishingServiceTest extends TestCase
 
         $environmentExists = true;
         $publishingEnabled = true;
-        $environmentMock1 = $this->getRemoteEnvironmentMock(false, $publishingEnabled);
-        $environmentMock2 = $this->getRemoteEnvironmentMock($environmentExists, $publishingEnabled);
+        $environmentMock1 = $this->getRemoteEnvironmentMock($environmentExists, $publishingEnabled);
+        $environmentMock2 = $this->getRemoteEnvironmentMock(false, $publishingEnabled);
 
         $this->ontologyMock
             ->method('getResource')
             ->willReturnOnConsecutiveCalls($deliveryResourceMock, $environmentMock1, $environmentMock2);
 
-        $task1 = $this->createMock(CallbackTaskInterface::class);
-        $this->queueDispatcherMock
-            ->method('createTask')
-            ->willReturnOnConsecutiveCalls($task1);
+        self::expectException(PublishingInvalidArgumentException::class);
 
-        $tasks = $this->subject->publishDeliveryToEnvironments($deliveryUri, $environments);
-
-        self::assertCount($expectedTasksAmount, $tasks, 'Method must return expected number of created tasks.');
-        self::assertInstanceOf(CallbackTaskInterface::class, $tasks[0]);
+        $this->subject->publishDeliveryToEnvironments($deliveryUri, $environments);
     }
 
-    public function testPublishDeliveryToEnvironments_PublishingToEnvironmentDisabled(): void
+    public function testPublishDeliveryToEnvironments_PublishingToEnvironmentDisabled_ThrowsException(): void
     {
         $deliveryUri = 'FAKE_DELIVERY_URI';
         $testUri = 'FAKE_TEST_URI';
         $environments = ['FAKE_ENVIRONMENT_URI_1', 'FAKE_ENVIRONMENT_URI_2'];
-        $expectedTasksAmount = 1;
 
         $testResourceMock = $this->getTestResourceMock($testUri);
         $deliveryExists = true;
@@ -213,15 +205,9 @@ class RemotePublishingServiceTest extends TestCase
             ->method('getResource')
             ->willReturnOnConsecutiveCalls($deliveryResourceMock, $environmentMock1, $environmentMock2);
 
-        $task1 = $this->createMock(CallbackTaskInterface::class);
-        $this->queueDispatcherMock
-            ->method('createTask')
-            ->willReturnOnConsecutiveCalls($task1);
+        self::expectException(PublishingInvalidArgumentException::class);
 
-        $tasks = $this->subject->publishDeliveryToEnvironments($deliveryUri, $environments);
-
-        self::assertCount($expectedTasksAmount, $tasks, 'Method must return expected number of created tasks.');
-        self::assertInstanceOf(CallbackTaskInterface::class, $tasks[0]);
+        $this->subject->publishDeliveryToEnvironments($deliveryUri, $environments);
     }
 
     /**


### PR DESCRIPTION
Remote environments are validated before creating async tasks. API updated to return informative messages about invalid params.
 
Related to : 
https://oat-sa.atlassian.net/browse/TAO-10404
https://oat-sa.atlassian.net/browse/TAO-10405
https://oat-sa.atlassian.net/browse/TAO-10406

First this PR changes how API request parameters are validated, both parameters, `delivery-uri` and `remote-environments`, must be included in the request body, with non-empty value(s). Secondly the `RemotePublishingService` is updated, in order to validate all provided environments before creating any tasks for publishing. In this case either tasks are created for all provided environments, or none of them. 

#### Steps to reproduce and test
 - QA has prepared 3 great tickets to describe the incorrect behavior and how to verify the fix in detail
 - In summary, submitting request without some of the parameters, or with an empty/invalid value, should return `400` response and informative message. Endpoint address is `taoPublishing/api/deliveries/publish`. List of different cases:
     - without or empty parameter `delivery-uri`
     - without or empty parameter `remote-environments`
     - provided `delivery-uri` parameter for non existing delivery
     - provided `remote-environments` parameter for non existing or disabled remote environment 
 
Test commands :
 
```
sudo -u www-data ./vendor/bin/phpunit taoPublishing/test/unit/
```
 