### PR TITLE
Fix/tao 10399/publish delivery custom properties

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '3.1.0',
+    'version' => '4.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=12.2.0',

--- a/model/publishing/delivery/PublishingDeliveryService.php
+++ b/model/publishing/delivery/PublishingDeliveryService.php
@@ -45,22 +45,7 @@ class PublishingDeliveryService extends ConfigurableService
 
     public const DELIVERY_REMOTE_SYNC_REST_OPTION = 'remote-publish';
 
-    public function getSynchronizedDeliveryProperties(core_kernel_classes_Resource $delivery): array
-    {
-        $propertyList = [];
-        foreach ($this->collectSynchronizedDeliveryFields() as $deliveryProperty) {
-            $value = $delivery->getOnePropertyValue($this->getProperty($deliveryProperty));
-            if ($value instanceof core_kernel_classes_Resource) {
-                $value = $value->getUri();
-            }
-            $propertyList[$deliveryProperty] = (string) $value;
-        }
-        $propertyList[self::ORIGIN_DELIVERY_ID_FIELD] = $delivery->getUri();
-
-        return $propertyList;
-    }
-
-    private function collectSynchronizedDeliveryFields(): array
+    public function getSyncFields(): array
     {
         $deliveryFieldsOptions = $this->getOption(PublishingService::OPTIONS_FIELDS);
         $deliveryExcludedFieldsOptions = $this->hasOption(PublishingService::OPTIONS_EXCLUDED_FIELDS)

--- a/model/publishing/delivery/PublishingDeliveryService.php
+++ b/model/publishing/delivery/PublishingDeliveryService.php
@@ -19,7 +19,14 @@
 
 namespace oat\taoPublishing\model\publishing\delivery;
 
+use core_kernel_classes_Class;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoPublishing\model\publishing\PublishingService;
+use tao_helpers_form_GenerisFormFactory;
 
 /**
  * Class PublishingDeliveryService
@@ -28,6 +35,8 @@ use oat\oatbox\service\ConfigurableService;
  */
 class PublishingDeliveryService extends ConfigurableService
 {
+    use OntologyAwareTrait;
+
     public const SERVICE_ID = 'taoPublishing/PublishingDeliveryService';
     public const ORIGIN_DELIVERY_ID_FIELD = 'http://www.tao.lu/Ontologies/TAOPublisher.rdf#OriginDeliveryID';
     public const ORIGIN_TEST_ID_FIELD = 'http://www.tao.lu/Ontologies/TAOPublisher.rdf#OriginTestID';
@@ -35,4 +44,40 @@ class PublishingDeliveryService extends ConfigurableService
     public const DELIVERY_REMOTE_SYNC_COMPILE_ENABLED = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#ComplyEnabled';
 
     public const DELIVERY_REMOTE_SYNC_REST_OPTION = 'remote-publish';
+
+    public function getSynchronizedDeliveryProperties(core_kernel_classes_Resource $delivery): array
+    {
+        $propertyList = [];
+        foreach ($this->collectSynchronizedDeliveryFields() as $deliveryProperty) {
+            $value = $delivery->getOnePropertyValue($this->getProperty($deliveryProperty));
+            if ($value instanceof core_kernel_classes_Resource) {
+                $value = $value->getUri();
+            }
+            $propertyList[$deliveryProperty] = (string) $value;
+        }
+        $propertyList[self::ORIGIN_DELIVERY_ID_FIELD] = $delivery->getUri();
+
+        return $propertyList;
+    }
+
+    private function collectSynchronizedDeliveryFields(): array
+    {
+        $deliveryFieldsOptions = $this->getOption(PublishingService::OPTIONS_FIELDS);
+        $deliveryExcludedFieldsOptions = $this->hasOption(PublishingService::OPTIONS_EXCLUDED_FIELDS)
+            ? $this->getOption(PublishingService::OPTIONS_EXCLUDED_FIELDS)
+            : [];
+        if (!$deliveryFieldsOptions) {
+            $deliveryClass = new core_kernel_classes_Class(DeliveryAssemblyService::CLASS_URI);
+            $deliveryProperties = tao_helpers_form_GenerisFormFactory::getClassProperties($deliveryClass);
+            $defaultProperties = tao_helpers_form_GenerisFormFactory::getDefaultProperties();
+            $deliveryProperties = array_merge($defaultProperties, $deliveryProperties);
+            /** @var core_kernel_classes_Property $deliveryProperty */
+            foreach ($deliveryProperties as $deliveryProperty) {
+                if (!in_array($deliveryProperty->getUri(), $deliveryExcludedFieldsOptions)) {
+                    $deliveryFieldsOptions[] = $deliveryProperty->getUri();
+                }
+            }
+        }
+        return $deliveryFieldsOptions;
+    }
 }

--- a/model/publishing/delivery/RemoteDeliveryPublisher.php
+++ b/model/publishing/delivery/RemoteDeliveryPublisher.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace oat\taoPublishing\model\publishing\delivery;
 
+use common_exception_InvalidArgumentType;
 use core_kernel_classes_Resource;
 use core_kernel_persistence_Exception;
 use GuzzleHttp\Exception\ClientException;
@@ -143,17 +144,18 @@ class RemoteDeliveryPublisher extends ConfigurableService
     /**
      * @param core_kernel_classes_Resource $delivery
      * @return array
-     * @throws core_kernel_persistence_Exception
+     * @throws common_exception_InvalidArgumentType
      */
     private function getSynchronizedDeliveryProperties(core_kernel_classes_Resource $delivery): array
     {
         $propertyList = [];
-        foreach ($this->getPublishingDeliveryService()->getSyncFields() as $deliveryProperty) {
-            $value = $delivery->getOnePropertyValue($this->getProperty($deliveryProperty));
+        $propertyValues = $delivery->getPropertiesValues($this->getPublishingDeliveryService()->getSyncFields());
+        foreach ($propertyValues as $propertyKey => $values) {
+            $value = reset($values);
             if ($value instanceof core_kernel_classes_Resource) {
                 $value = $value->getUri();
             }
-            $propertyList[$deliveryProperty] = (string) $value;
+            $propertyList[$propertyKey] = (string) $value;
         }
         $propertyList[PublishingDeliveryService::ORIGIN_DELIVERY_ID_FIELD] = $delivery->getUri();
 

--- a/model/publishing/delivery/RemoteDeliveryPublisher.php
+++ b/model/publishing/delivery/RemoteDeliveryPublisher.php
@@ -105,10 +105,8 @@ class RemoteDeliveryPublisher extends ConfigurableService
                 [
                     'name' => RestTest::REST_DELIVERY_PARAMS,
                     'contents' => json_encode(
-                        [
-                            PublishingDeliveryService::ORIGIN_DELIVERY_ID_FIELD => $this->delivery->getUri()
-                        ]
-                    )
+                        $this->getPublishingDeliveryService()->getSynchronizedDeliveryProperties($this->delivery)
+                    ),
                 ]
             ];
 
@@ -178,6 +176,11 @@ class RemoteDeliveryPublisher extends ConfigurableService
     private function getPlatformService(): PlatformService
     {
         return $this->getServiceLocator()->get(PlatformService::class);
+    }
+
+    private function getPublishingDeliveryService(): PublishingDeliveryService
+    {
+        return $this->getServiceLocator()->get(PublishingDeliveryService::SERVICE_ID);
     }
 
     /**

--- a/model/publishing/delivery/RemoteDeliveryPublisher.php
+++ b/model/publishing/delivery/RemoteDeliveryPublisher.php
@@ -104,9 +104,7 @@ class RemoteDeliveryPublisher extends ConfigurableService
                 ],
                 [
                     'name' => RestTest::REST_DELIVERY_PARAMS,
-                    'contents' => json_encode(
-                        $this->getPublishingDeliveryService()->getSynchronizedDeliveryProperties($this->delivery)
-                    ),
+                    'contents' => json_encode($this->getSynchronizedDeliveryProperties($this->delivery)),
                 ]
             ];
 
@@ -140,6 +138,26 @@ class RemoteDeliveryPublisher extends ConfigurableService
             ->get(FileSystemService::SERVICE_ID)
             ->getDirectory(TestBackupService::FILESYSTEM_ID)
             ->getFile($packagePath);
+    }
+
+    /**
+     * @param core_kernel_classes_Resource $delivery
+     * @return array
+     * @throws core_kernel_persistence_Exception
+     */
+    private function getSynchronizedDeliveryProperties(core_kernel_classes_Resource $delivery): array
+    {
+        $propertyList = [];
+        foreach ($this->getPublishingDeliveryService()->getSyncFields() as $deliveryProperty) {
+            $value = $delivery->getOnePropertyValue($this->getProperty($deliveryProperty));
+            if ($value instanceof core_kernel_classes_Resource) {
+                $value = $value->getUri();
+            }
+            $propertyList[$deliveryProperty] = (string) $value;
+        }
+        $propertyList[PublishingDeliveryService::ORIGIN_DELIVERY_ID_FIELD] = $delivery->getUri();
+
+        return $propertyList;
     }
 
     /**

--- a/model/publishing/delivery/tasks/RemoteTaskStatusSynchroniser.php
+++ b/model/publishing/delivery/tasks/RemoteTaskStatusSynchroniser.php
@@ -26,11 +26,16 @@ class RemoteTaskStatusSynchroniser implements Action,ServiceLocatorAwareInterfac
     use ServiceLocatorAwareTrait;
     use OntologyAwareTrait;
 
-    private $status;
+    private const FINAL_TASK_STATUSES = [
+        CategorizedStatus::STATUS_COMPLETED,
+        CategorizedStatus::STATUS_CANCELLED,
+        CategorizedStatus::STATUS_FAILED,
+        CategorizedStatus::STATUS_ARCHIVED
+    ];
 
+    private $status;
     private $remoteTaskId;
     private $remoteEnvironmentId;
-
     private $remoteDeliveryId = null;
 
     public function getRemoteStatus()
@@ -100,15 +105,7 @@ class RemoteTaskStatusSynchroniser implements Action,ServiceLocatorAwareInterfac
 
     private function isTaskFinished(string $status): bool
     {
-        return in_array(
-            $status,
-            [
-                CategorizedStatus::STATUS_COMPLETED,
-                CategorizedStatus::STATUS_CANCELLED,
-                CategorizedStatus::STATUS_FAILED,
-                CategorizedStatus::STATUS_ARCHIVED
-            ]
-        );
+        return in_array($status, self::FINAL_TASK_STATUSES);
     }
 
     private function prepareRemoteTaskExecutionReport(Report $remoteTaskReport): Report

--- a/test/unit/model/publishing/delivery/RemoteDeliveryPublisherTest.php
+++ b/test/unit/model/publishing/delivery/RemoteDeliveryPublisherTest.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\taoPublishing\test\unit\model\publishing\delivery;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use League\Flysystem\FileNotFoundException;
+use oat\generis\model\data\Ontology;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\filesystem\Directory;
+use oat\oatbox\filesystem\File;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\taoPublishing\model\PlatformService;
+use oat\taoPublishing\model\publishing\delivery\RemoteDeliveryPublisher;
+use oat\taoPublishing\model\publishing\exception\PublishingFailedException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
+
+class RemoteDeliveryPublisherTest extends TestCase
+{
+    /** @var RemoteDeliveryPublisher */
+    private $subject;
+
+    /** @var Ontology|MockObject */
+    private $ontologyMock;
+
+    /** @var FileSystemService|MockObject */
+    private $fileSystemServiceMock;
+
+    /** @var PlatformService|MockObject */
+    private $platformServiceMock;
+
+    /** @var core_kernel_classes_Resource */
+    private $delivery;
+
+    /** @var core_kernel_classes_Resource */
+    private $environment;
+
+    /** @var core_kernel_classes_Resource */
+    private $test;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ontologyMock = $this->createMock(Ontology::class);
+        $this->fileSystemServiceMock = $this->createMock(FileSystemService::class);
+        $this->platformServiceMock = $this->createMock(PlatformService::class);
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $serviceLocatorMock = $this->getServiceLocatorMock(
+            [
+                FileSystemService::SERVICE_ID => $this->fileSystemServiceMock,
+                PlatformService::class => $this->platformServiceMock
+            ]
+        );
+
+        $this->subject = new RemoteDeliveryPublisher();
+        $this->subject->setModel($this->ontologyMock);
+        $this->subject->setLogger($loggerMock);
+        $this->subject->setServiceLocator($serviceLocatorMock);
+    }
+
+    /**
+     * @return core_kernel_classes_Resource|MockObject
+     */
+    private function getResourceMock(string $uri, string $label, bool $resourceExists): core_kernel_classes_Resource
+    {
+        $resourceMock = $this->createMock(core_kernel_classes_Resource::class);
+        $resourceMock->method('getUri')
+            ->willReturn($uri);
+        $resourceMock->method('getLabel')
+            ->willReturn($label);
+        $resourceMock->method('exists')
+            ->willReturn($resourceExists);
+
+        return $resourceMock;
+    }
+
+    public function testPublishReturnRemoteTaskId(): void
+    {
+        $expectedRemoteTaskId = 'DUMMY_REMOTE_TASK_ID';
+
+        $delivery = $this->getResourceMock('DUMMY_DELIVERY_URI', 'DUMMY_DELIVERY_LABEL', true);
+        $environment = $this->getResourceMock('DUMMY_ENV_URI', 'DUMMY_ENV_LABEL', true);
+        $test = $this->getResourceMock('DUMMY_TEST_URI', 'DUMMY_TEST_LABEL', true);
+
+        // Mock request data preparation
+        $this->mockCorrectRequestData($delivery);
+
+        // Mock API call response
+        $successResponse = sprintf('{"success":true, "data":{"reference_id":"%s"}}', $expectedRemoteTaskId);
+        $responseMock = $this->getApiResponseMock(200, $successResponse);
+        $this->platformServiceMock
+            ->method('callApi')
+            ->willReturn($responseMock);
+
+        $remoteTaskId = $this->subject->publish($delivery, $environment, $test);
+        self::assertSame($expectedRemoteTaskId, $remoteTaskId, "Method must return remote task ID.");
+    }
+
+    public function testPublish_WhenDeliveryDontExist_ThenThrowsException(): void {
+        $delivery = $this->getResourceMock('DUMMY_DELIVERY_URI', 'DUMMY_DELIVERY_LABEL', false);
+        $environment = $this->getResourceMock('DUMMY_ENV_URI', 'DUMMY_ENV_LABEL', true);
+        $test = $this->getResourceMock('DUMMY_TEST_URI', 'DUMMY_TEST_LABEL', true);
+
+        self::expectException(PublishingFailedException::class);
+
+        $this->subject->publish($delivery, $environment, $test);
+    }
+
+    public function testPublish_WhenEnvironmentDontExist_ThenThrowsException(): void {
+        $delivery = $this->getResourceMock('DUMMY_DELIVERY_URI', 'DUMMY_DELIVERY_LABEL', true);
+        $environment = $this->getResourceMock('DUMMY_ENV_URI', 'DUMMY_ENV_LABEL', false);
+        $test = $this->getResourceMock('DUMMY_TEST_URI', 'DUMMY_TEST_LABEL', true);
+
+        self::expectException(PublishingFailedException::class);
+
+        $this->subject->publish($delivery, $environment, $test);
+    }
+
+    public function testPublish_WhenQtiTestBackupDontExist_ThenThrowsException(): void {
+        $delivery = $this->getResourceMock('DUMMY_DELIVERY_URI', 'DUMMY_DELIVERY_LABEL', true);
+        $environment = $this->getResourceMock('DUMMY_ENV_URI', 'DUMMY_ENV_LABEL', true);
+        $test = $this->getResourceMock('DUMMY_TEST_URI', 'DUMMY_TEST_LABEL', true);
+
+        // Mock invalid request data preparation
+        $backupPropertyMock = $this->createMock(core_kernel_classes_Property::class);
+        $this->ontologyMock
+            ->method('getProperty')
+            ->willReturn($backupPropertyMock);
+        $delivery->method('getOnePropertyValue')
+            ->willReturn('DUMMY_PACKAGE_PATH');
+
+        $fileMock = $this->getBackupFileMock();
+        $fileMock->method('readPsrStream')
+            ->willThrowException(new FileNotFoundException('DUMMY_PATH'));
+
+        self::expectException(PublishingFailedException::class);
+
+        $this->subject->publish($delivery, $environment, $test);
+    }
+
+    public function testPublish_WhenConnectionFailed_ThenThrowsException(): void {
+        $delivery = $this->getResourceMock('DUMMY_DELIVERY_URI', 'DUMMY_DELIVERY_LABEL', true);
+        $environment = $this->getResourceMock('DUMMY_ENV_URI', 'DUMMY_ENV_LABEL', true);
+        $test = $this->getResourceMock('DUMMY_TEST_URI', 'DUMMY_TEST_LABEL', true);
+
+        // Mock request data preparation
+        $this->mockCorrectRequestData($delivery);
+
+        // Mock API call response
+        $requestMock = $this->createMock(RequestInterface::class);
+        $this->platformServiceMock
+            ->method('callApi')
+            ->willThrowException(new ConnectException('DUMMY_MESSAGE', $requestMock));
+
+        self::expectException(PublishingFailedException::class);
+
+        $this->subject->publish($delivery, $environment, $test);
+    }
+
+    public function testPublish_WhenBadRequest_ThenThrowsException(): void {
+        $delivery = $this->getResourceMock('DUMMY_DELIVERY_URI', 'DUMMY_DELIVERY_LABEL', true);
+        $environment = $this->getResourceMock('DUMMY_ENV_URI', 'DUMMY_ENV_LABEL', true);
+        $test = $this->getResourceMock('DUMMY_TEST_URI', 'DUMMY_TEST_LABEL', true);
+
+        // Mock request data preparation
+        $this->mockCorrectRequestData($delivery);
+
+        // Mock API call response
+        $requestMock = $this->createMock(RequestInterface::class);
+        $responseMock = $this->getApiResponseMock(400, '');
+        $this->platformServiceMock
+            ->method('callApi')
+            ->willThrowException(new ClientException('DUMMY_MESSAGE', $requestMock, $responseMock));
+
+        self::expectException(PublishingFailedException::class);
+
+        $this->subject->publish($delivery, $environment, $test);
+    }
+
+    /**
+     * @param int $statusCode
+     * @param string $responseBody
+     *
+     * @dataProvider dataProviderUnsuccessfulApiResponse
+     */
+    public function testPublish_WhenResponseUnsuccessful_ThenThrowsException(
+        int $statusCode,
+        string $responseBody
+    ): void {
+        $delivery = $this->getResourceMock('DUMMY_DELIVERY_URI', 'DUMMY_DELIVERY_LABEL', true);
+        $environment = $this->getResourceMock('DUMMY_ENV_URI', 'DUMMY_ENV_LABEL', true);
+        $test = $this->getResourceMock('DUMMY_TEST_URI', 'DUMMY_TEST_LABEL', true);
+
+        // Mock request data preparation
+        $this->mockCorrectRequestData($delivery);
+
+        // Mock API call response
+        $responseMock = $this->getApiResponseMock($statusCode, $responseBody);
+        $this->platformServiceMock
+            ->method('callApi')
+            ->willReturn($responseMock);
+
+        self::expectException(PublishingFailedException::class);
+
+        $this->subject->publish($delivery, $environment, $test);
+    }
+
+    /**
+     * @return File|MockObject
+     */
+    private function getBackupFileMock(): File
+    {
+
+        $fileMock = $this->createMock(File::class);
+        $directoryMock = $this->createMock(Directory::class);
+        $directoryMock->method('getFile')
+            ->willReturn($fileMock);
+        $this->fileSystemServiceMock
+            ->method('getDirectory')
+            ->willReturn($directoryMock);
+
+        return $fileMock;
+    }
+
+    /**
+     * @param int $statusCode
+     * @param string $responseBody
+     * @return ResponseInterface| MockObject
+     */
+    private function getApiResponseMock(int $statusCode, string $responseBody): ResponseInterface
+    {
+        $responseBodyMock = $this->createMock(StreamInterface::class);
+        $responseBodyMock->method('getContents')
+            ->willReturn($responseBody);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('getStatusCode')
+            ->willReturn(200);
+        $responseMock->method('getBody')
+            ->willReturn($responseBodyMock);
+
+        return $responseMock;
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderUnsuccessfulApiResponse(): array
+    {
+        return [
+            'Unsuccessful status code' => [
+                'statusCode' => 500,
+                'responseBody' => '{"success":false, "errorMsg": "DUMMY ERROR MESSAGE"}',
+            ],
+            'Status code OK, unsuccessful response' => [
+                'statusCode' => 200,
+                'responseBody' => '{"success":false, "errorMsg": "DUMMY ERROR MESSAGE"}',
+            ],
+            'Status code OK, successful response, no remote task ID' => [
+                'statusCode' => 200,
+                'responseBody' => '{"success":false, "data": {}}',
+            ]
+        ];
+    }
+
+    /**
+     * @param $delivery
+     */
+    private function mockCorrectRequestData($delivery): void
+    {
+        $backupPropertyMock = $this->createMock(core_kernel_classes_Property::class);
+        $this->ontologyMock
+            ->method('getProperty')
+            ->willReturn($backupPropertyMock);
+        $delivery->method('getOnePropertyValue')
+            ->willReturn('DUMMY_PACKAGE_PATH');
+
+        $streamMock = $this->createMock(StreamInterface::class);
+        $streamMock->method('isReadable')
+            ->willReturn(true);
+        $fileMock = $this->getBackupFileMock();
+        $fileMock->method('readPsrStream')
+            ->willReturn($streamMock);
+
+        $deliveryClassMock = $this->createMock(core_kernel_classes_Class::class);
+        $delivery->method('getTypes')
+            ->willReturn([$deliveryClassMock]);
+    }
+}
+

--- a/test/unit/model/publishing/delivery/RemoteDeliveryPublisherTest.php
+++ b/test/unit/model/publishing/delivery/RemoteDeliveryPublisherTest.php
@@ -33,6 +33,7 @@ use oat\oatbox\filesystem\Directory;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\filesystem\FileSystemService;
 use oat\taoPublishing\model\PlatformService;
+use oat\taoPublishing\model\publishing\delivery\PublishingDeliveryService;
 use oat\taoPublishing\model\publishing\delivery\RemoteDeliveryPublisher;
 use oat\taoPublishing\model\publishing\exception\PublishingFailedException;
 use Psr\Http\Message\RequestInterface;
@@ -74,7 +75,8 @@ class RemoteDeliveryPublisherTest extends TestCase
         $serviceLocatorMock = $this->getServiceLocatorMock(
             [
                 FileSystemService::SERVICE_ID => $this->fileSystemServiceMock,
-                PlatformService::class => $this->platformServiceMock
+                PlatformService::class => $this->platformServiceMock,
+                PublishingDeliveryService::SERVICE_ID => $this->createMock(PublishingDeliveryService::class)
             ]
         );
 

--- a/test/unit/model/publishing/delivery/RemoteDeliveryPublisherTest.php
+++ b/test/unit/model/publishing/delivery/RemoteDeliveryPublisherTest.php
@@ -55,28 +55,20 @@ class RemoteDeliveryPublisherTest extends TestCase
     /** @var PlatformService|MockObject */
     private $platformServiceMock;
 
-    /** @var core_kernel_classes_Resource */
-    private $delivery;
-
-    /** @var core_kernel_classes_Resource */
-    private $environment;
-
-    /** @var core_kernel_classes_Resource */
-    private $test;
-
     protected function setUp(): void
     {
         parent::setUp();
         $this->ontologyMock = $this->createMock(Ontology::class);
         $this->fileSystemServiceMock = $this->createMock(FileSystemService::class);
         $this->platformServiceMock = $this->createMock(PlatformService::class);
+        $publishingDeliveryServiceMock = $this->createMock(PublishingDeliveryService::class);
 
         $loggerMock = $this->createMock(LoggerInterface::class);
         $serviceLocatorMock = $this->getServiceLocatorMock(
             [
                 FileSystemService::SERVICE_ID => $this->fileSystemServiceMock,
                 PlatformService::class => $this->platformServiceMock,
-                PublishingDeliveryService::SERVICE_ID => $this->createMock(PublishingDeliveryService::class)
+                PublishingDeliveryService::SERVICE_ID => $publishingDeliveryServiceMock,
             ]
         );
 
@@ -98,6 +90,8 @@ class RemoteDeliveryPublisherTest extends TestCase
             ->willReturn($label);
         $resourceMock->method('exists')
             ->willReturn($resourceExists);
+        $resourceMock->method('getPropertiesValues')
+            ->willReturn([]);
 
         return $resourceMock;
     }


### PR DESCRIPTION
Include delivery properties to publishing payload
 
Related to : https://oat-sa.atlassian.net/browse/TAO-10399
 
Updated payload for delivery publishing payload, not only the `OriginDeliveryId` is included, but also other delivery fields, that are configured in `PublishingService::OPTIONS_FIELDS` and `PublishingService::OPTIONS_EXCLUDED_FIELDS`. 
 
#### Steps to reproduce and test
 - Go to 'Deliveries' tab
 - Select delivery, change any Properties (Start or End date, Title, Max. Executions, Display Order)
 - Save and Click "Publish To Remote" button
 - Check delivery on remote environment after publishing
 - Verify that delivery properties have been synced

Requires :
 - [x] https://github.com/oat-sa/extension-tao-delivery-rdf/pull/354