### PR TITLE
UNO-392 BREAKING CHANGE: require a major update of `tao`

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -19,16 +20,23 @@
  *
  */
 
+use oat\taoPublishing\model\routing\ApiRoute;
+use oat\taoPublishing\scripts\install\RegisterDeliveryEventsListener;
+use oat\taoPublishing\scripts\install\RegisterGenerisSearch;
+use oat\taoPublishing\scripts\install\RegisterPublishingFileSystem;
+use oat\taoPublishing\scripts\install\UpdateConfigDeliveryFactoryService;
+use oat\taoPublishing\scripts\update\Updater;
+
 return array(
     'name' => 'taoPublishing',
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '4.0.1',
+    'version' => '5.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoDeliveryRdf' => '>=12.2.1',
-        'tao' => '>=31.6.0',
+        'tao' => '>=45.0.0',
         'taoQtiTest' => '>=38.13.0',
     ),
 	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoPublishingManager',
@@ -43,22 +51,22 @@ return array(
             __DIR__. '/model/ontology/indexation.rdf'
         ),
         'php' => array(
-            \oat\taoPublishing\scripts\install\UpdateConfigDeliveryFactoryService::class,
-            \oat\taoPublishing\scripts\install\RegisterGenerisSearch::class,
-            \oat\taoPublishing\scripts\install\RegisterDeliveryEventsListener::class,
-            \oat\taoPublishing\scripts\install\RegisterPublishingFileSystem::class,
+            UpdateConfigDeliveryFactoryService::class,
+            RegisterGenerisSearch::class,
+            RegisterDeliveryEventsListener::class,
+            RegisterPublishingFileSystem::class,
         )
     ),
     'uninstall' => array(
     ),
     'routes' => array(
-        '/taoPublishing/api' => ['class' => \oat\taoPublishing\model\routing\ApiRoute::class],
+        '/taoPublishing/api' => ['class' => ApiRoute::class],
         '/taoPublishing' => 'oat\\taoPublishing\\controller'
     ),
-    'update' => 'oat\\taoPublishing\\scripts\\update\\Updater',
+    'update' => Updater::class,
 	'constants' => array(
 	    # views directory
-	    "DIR_VIEWS" => dirname(__FILE__).DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
+	    "DIR_VIEWS" => __DIR__ .DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
 
 		#BASE URL (usually the domain root)
 		'BASE_URL' => ROOT_URL.'taoPublishing/',
@@ -67,6 +75,6 @@ return array(
 	    'BASE_WWW' => ROOT_URL.'taoPublishing/views/'
 	),
     'extra' => array(
-        'structures' => dirname(__FILE__).DIRECTORY_SEPARATOR.'controller'.DIRECTORY_SEPARATOR.'structures.xml',
+        'structures' => __DIR__ .DIRECTORY_SEPARATOR.'controller'.DIRECTORY_SEPARATOR.'structures.xml',
     )
 );

--- a/model/widget/AuthWidget.php
+++ b/model/widget/AuthWidget.php
@@ -1,29 +1,32 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2016 (original work) Open Assessment Technologies SA
  */
+
 namespace oat\taoPublishing\model\widget;
+
+use tao_helpers_form_elements_xhtml_Textbox;
+
 /**
  * Widget to render authentication
  *
  * @access public
  */
-class AuthWidget extends \tao_helpers_form_elements_xhtml_Textbox
+class AuthWidget extends tao_helpers_form_elements_xhtml_Textbox
 {
-    protected $widget = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#AuthenticationIdentity';
-    
+    public const WIDGET_ID = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#AuthenticationIdentity';
 }


### PR DESCRIPTION
- [UNO-392](https://oat-sa.atlassian.net/browse/UNO-392) BREAKING CHANGE: require a major update of `tao`
- [UNO-392](https://oat-sa.atlassian.net/browse/UNO-392) chore: use `WIDGET_ID` constant instead of a deprecated `$widget` property to define `AuthWidget`'s widget URI

⚠️ Depends on `tao-core` [#2609](https://github.com/oat-sa/tao-core/pull/2609).