### PR TITLE
Fix/BSA-227/Wrong delivery class on the remote environment

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,10 +32,10 @@ return array(
 	'label' => 'Test Publishing',
 	'description' => 'An extension to publish tests to a delivery environment',
     'license' => 'GPL-2.0',
-    'version' => '5.0.0',
+    'version' => '5.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'taoDeliveryRdf' => '>=12.2.1',
+        'taoDeliveryRdf' => '>=13.1.0',
         'tao' => '>=45.0.0',
         'taoQtiTest' => '>=38.13.0',
     ),

--- a/model/publishing/delivery/RemoteDeliveryPublisher.php
+++ b/model/publishing/delivery/RemoteDeliveryPublisher.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace oat\taoPublishing\model\publishing\delivery;
 
+use core_kernel_classes_Class as CoreClass;
 use common_exception_InvalidArgumentType;
 use core_kernel_classes_Resource;
 use core_kernel_persistence_Exception;
@@ -72,6 +73,26 @@ class RemoteDeliveryPublisher extends ConfigurableService
         return $this->processApiResponse($response);
     }
 
+    /**
+     * @param CoreClass $deliveryClass
+     *
+     * @return array
+     */
+    protected function getParentLabels(CoreClass $deliveryClass): array
+    {
+        $labels = [];
+
+        foreach ($deliveryClass->getParentClasses(true) as $parentClass) {
+            if ($parentClass->getUri() === DeliveryAssemblyService::CLASS_URI) {
+                break;
+            }
+
+            $labels[] = $parentClass->getLabel();
+        }
+
+        return $labels;
+    }
+
     private function validateResources(): void
     {
         if (!$this->delivery->exists()) {
@@ -115,15 +136,7 @@ class RemoteDeliveryPublisher extends ConfigurableService
             $deliveryClass = current($this->delivery->getTypes());
 
             if ($deliveryClass->getUri() !== DeliveryAssemblyService::CLASS_URI) {
-                $labels = [];
-
-                foreach ($deliveryClass->getParentClasses(true) as $parentClass) {
-                    if ($parentClass->getUri() === DeliveryAssemblyService::CLASS_URI) {
-                        break;
-                    }
-
-                    $labels[] = $parentClass->getLabel();
-                }
+                $labels = $this->getParentLabels($deliveryClass);
 
                 $labels[] = $deliveryClass->getLabel();
 

--- a/model/publishing/delivery/RemoteDeliveryPublisher.php
+++ b/model/publishing/delivery/RemoteDeliveryPublisher.php
@@ -86,8 +86,11 @@ class RemoteDeliveryPublisher extends ConfigurableService
     }
 
     /**
-     * @return array
+     * @throws PublishingFailedException
+     * @throws common_exception_InvalidArgumentType
      * @throws core_kernel_persistence_Exception
+     *
+     * @return array
      */
     private function prepareRequestData(): array
     {
@@ -110,18 +113,34 @@ class RemoteDeliveryPublisher extends ConfigurableService
             ];
 
             $deliveryClass = current($this->delivery->getTypes());
-            if ($deliveryClass->getUri() != DeliveryAssemblyService::CLASS_URI) {
+
+            if ($deliveryClass->getUri() !== DeliveryAssemblyService::CLASS_URI) {
+                $labels = [];
+
+                foreach ($deliveryClass->getParentClasses(true) as $parentClass) {
+                    if ($parentClass->getUri() === DeliveryAssemblyService::CLASS_URI) {
+                        break;
+                    }
+
+                    $labels[] = $parentClass->getLabel();
+                }
+
+                $labels[] = $deliveryClass->getLabel();
+
                 $requestData[] = [
-                    'name' => RestTest::REST_DELIVERY_CLASS_LABEL,
-                    'contents' => $deliveryClass->getLabel()
+                    'name' => RestTest::REST_DELIVERY_CLASS_LABELS,
+                    'contents' => json_encode($labels),
                 ];
             }
 
             return $requestData;
         } catch (FileNotFoundException $e) {
             $this->logError($e->getMessage(), [$e->__toString()]);
-            $message = sprintf(__('QTI Test backup file not found for delivery "%s"'), $this->delivery->getLabel());
-            throw new PublishingFailedException($message);
+
+            throw new PublishingFailedException(sprintf(
+                __('QTI Test backup file not found for delivery "%s"'),
+                $this->delivery->getLabel()
+            ));
         }
     }
 

--- a/model/publishing/delivery/RemoteDeliveryPublisher.php
+++ b/model/publishing/delivery/RemoteDeliveryPublisher.php
@@ -90,7 +90,7 @@ class RemoteDeliveryPublisher extends ConfigurableService
             $labels[] = $parentClass->getLabel();
         }
 
-        return $labels;
+        return array_reverse($labels);
     }
 
     private function validateResources(): void

--- a/test/unit/model/publishing/delivery/RemoteDeliveryPublisherTest.php
+++ b/test/unit/model/publishing/delivery/RemoteDeliveryPublisherTest.php
@@ -72,7 +72,15 @@ class RemoteDeliveryPublisherTest extends TestCase
             ]
         );
 
-        $this->subject = new RemoteDeliveryPublisher();
+
+
+        $this->subject = $this->getMockBuilder(RemoteDeliveryPublisher::class)
+            ->onlyMethods(['getParentLabels'])
+            ->getMock();
+        $this->subject
+            ->expects(self::atMost(1))
+            ->method('getParentLabels')
+            ->willReturn([]);
         $this->subject->setModel($this->ontologyMock);
         $this->subject->setLogger($loggerMock);
         $this->subject->setServiceLocator($serviceLocatorMock);


### PR DESCRIPTION
Relates to: [BSA-227](https://oat-sa.atlassian.net/browse/BSA-227)

**Changes:** an array of parent labels (instead of a single parent label) will be sent to the delivery environment.

**How to test:**
1. create some nested delivery classes on Authoring environment;
2. create a delivery in the last nested class;
3. publish this delivery to the Delivery environment;
4. go to the Delivery environment and open `deliveries`;
5. check published delivery.

**Old:** _delivery published in the wrong class_.
**New:** _delivery published in the correct class_.

Requires: [#360](https://github.com/oat-sa/extension-tao-delivery-rdf/pull/360)