### PR TITLE
fix: added the ExcludedSubjects field to the excluded_fields list

### DIFF
--- a/config/default/PublishingDeliveryService.conf.php
+++ b/config/default/PublishingDeliveryService.conf.php
@@ -13,6 +13,7 @@ return new oat\taoPublishing\model\publishing\delivery\PublishingDeliveryService
         \oat\taoDeliveryRdf\model\DeliveryAssemblyService::PROPERTY_ORIGIN,
         \oat\taoPublishing\model\publishing\delivery\PublishingDeliveryService::ORIGIN_DELIVERY_ID_FIELD,
         \oat\taoPublishing\model\publishing\delivery\PublishingDeliveryService::DELIVERY_REMOTE_SYNC_FIELD,
+        \oat\taoDeliveryRdf\model\DeliveryContainerService::PROPERTY_EXCLUDED_SUBJECTS,
 
         // Using strings for ignoring taoClientRestricted in require
         'http://www.tao.lu/Ontologies/TAODelivery.rdf#RestrictBrowserUsage',

--- a/migrations/Version202206271510143635_taoPublishing.php
+++ b/migrations/Version202206271510143635_taoPublishing.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoPublishing\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoDeliveryRdf\model\DeliveryContainerService;
+use oat\taoPublishing\model\publishing\delivery\PublishingDeliveryService;
+use oat\taoPublishing\model\publishing\PublishingService;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202206271510143635_taoPublishing extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Setting the new excluded field for the delivery publishing';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $service = $this->getServiceLocator()->get(PublishingDeliveryService::SERVICE_ID);
+        $deliveryExcludedFieldsOptions = $service->getOption(PublishingService::OPTIONS_EXCLUDED_FIELDS);
+
+        if (!array_search(DeliveryContainerService::PROPERTY_EXCLUDED_SUBJECTS, $deliveryExcludedFieldsOptions)) {
+            // Using strings for ignoring ExcludedSubjects in require
+            $deliveryExcludedFieldsOptions[] = DeliveryContainerService::PROPERTY_EXCLUDED_SUBJECTS;
+        }
+
+        $service->setOption(PublishingService::OPTIONS_EXCLUDED_FIELDS, $deliveryExcludedFieldsOptions);
+        $this->getServiceManager()->register(PublishingDeliveryService::SERVICE_ID, $service);
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        $service = $this->getServiceLocator()->get(PublishingDeliveryService::SERVICE_ID);
+        $deliveryExcludedFieldsOptions = $service->getOption(PublishingService::OPTIONS_EXCLUDED_FIELDS);
+
+        $to_remove = [DeliveryContainerService::PROPERTY_EXCLUDED_SUBJECTS];
+        $result = array_diff($deliveryExcludedFieldsOptions, $to_remove);
+
+        $service->setOption(PublishingService::OPTIONS_EXCLUDED_FIELDS, $result);
+        $this->getServiceManager()->register(PublishingDeliveryService::SERVICE_ID, $service);
+
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/OATSD-1883
https://oat-sa.atlassian.net/browse/TR-4195
https://oat-sa.atlassian.net/browse/TR-4191

For remote publishing, we generate a full list of delivery properties which should be sent to a remote environment. Because we don't have any sync for TT between environments and because we should not send any empty values, we need to exclude that property from the publishing list.

How to test:

1. Create a delivery on env1
2. Publish the delivery from env1 to env2 using the remote publishing
3. Check that on the env2 the new delivery doesn't contain the empty values in the ExcludedSubjects property.
