### PR TITLE
fix: Add default null value for webhookId property

### DIFF
--- a/model/publishing/delivery/tasks/RemoteDeliveryPublishingTask.php
+++ b/model/publishing/delivery/tasks/RemoteDeliveryPublishingTask.php
@@ -59,7 +59,7 @@ class RemoteDeliveryPublishingTask implements Action, ServiceLocatorAwareInterfa
     private $environment;
 
     /** @var string|null */
-    private ?string $webhookId;
+    private ?string $webhookId = null;
 
     /**
      * @param array  $params


### PR DESCRIPTION
When there is no `http://www.tao.lu/Ontologies/TaoPlatform.rdf#PublishingWebhook` error occurs with message
```
2025-01-03 12:11:24 [ERROR] [tao] 'Typed property oat\taoPublishing\model\publishing\delivery\tasks\RemoteDeliveryPublishingTask::$webhookId must not be accessed before initialization' /var/www/html/tao/taoPublishing/model/publishing/delivery/tasks/RemoteDeliveryPublishingTask.php 125

```